### PR TITLE
add dplyr to the Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ License: GPL-3
 LazyData: TRUE
 Imports:
     dplyr,
+    rlang (>= 0.4.6),
     httr,
     jsonlite,
     stringi,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ License: GPL-3
 LazyData: TRUE
 Imports:
     dplyr,
-    rlang (>= 0.4.6),
     httr,
     jsonlite,
     stringi,

--- a/FixForMissingDplyrImport
+++ b/FixForMissingDplyrImport
@@ -11,6 +11,7 @@ Description: Provides a set of functions and a class to connect, extract and
 License: GPL-3
 LazyData: TRUE
 Imports:
+    dplyr,
     httr,
     jsonlite,
     stringi,


### PR DESCRIPTION
dplyr is used in this package, but is not included in the Imports - leading to failed package installs on clean systems