### PR TITLE
Column type conversion when all character elements are NA

### DIFF
--- a/R/classConstructor.R
+++ b/R/classConstructor.R
@@ -1341,7 +1341,12 @@ dsws$methods(.processSnapshot = function(format, myNumDatatype, isChunked, chunk
       # If column contains multiple datatypes and at least one of these is of the character type (i.e. type 6),
       # then check if all the character elements are "NA" and, if so, prevent column conversion to character type:
       if(any(myType==6)&length(unique(myType))>1){
-        if(all(sapply(mylist, FUN=function(x) x$Value)[myType==6]=='NA')) myType <- myType[myType!=6]
+
+        charValues <- sapply(.self$dataResponse$DataResponse$DataTypeValues[[iDatatype]]$SymbolValues,
+                             FUN=function(x) x$Value,
+                             simplify=TRUE)[myType==6]
+
+        if(all(charValues=='NA')) myType <- myType[myType!=6]
       }
 
       .self$myTypes[iDatatype] <- round(median(as.numeric(myType), na.rm = TRUE))

--- a/R/classConstructor.R
+++ b/R/classConstructor.R
@@ -1337,6 +1337,13 @@ dsws$methods(.processSnapshot = function(format, myNumDatatype, isChunked, chunk
       myType <- sapply(.self$dataResponse$DataResponse$DataTypeValues[[iDatatype]]$SymbolValues,
                        FUN = .getType,
                        simplify = TRUE)
+
+      # If column contains multiple datatypes and at least one of these is of the character type (i.e. type 6),
+      # then check if all the character elements are "NA" and, if so, prevent column conversion to character type:
+      if(any(myType==6)&length(unique(myType))>1){
+        if(all(sapply(mylist, FUN=function(x) x$Value)[myType==6]=='NA')) myType <- myType[myType!=6]
+      }
+
       .self$myTypes[iDatatype] <- round(median(as.numeric(myType), na.rm = TRUE))
 
       # On the first loop, we need to check what the type of data is, and if a Date


### PR DESCRIPTION
For fields with multiple datatypes including some elements of the character type, this code checks if the elements of the character type are all "NA" and, if so, excludes the character datatype when determining the column's type.